### PR TITLE
Hotfix/is plugin active

### DIFF
--- a/classes/sink.php
+++ b/classes/sink.php
@@ -220,7 +220,7 @@ class Sink
 
     public function isActive()
     {
-        if (!\is_plugin_active($this->plugin_slug)) {
+        if (function_exists('is_plugin_active') && !\is_plugin_active($this->plugin_slug)) {
             return false;
         }
 

--- a/sink.php
+++ b/sink.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Sink
  * Description: Sync media to S3 seamlessly
- * Version:     1.0.4
+ * Version:     1.0.5
  * Author:      Caffeina
  * Author URI:  https://caffeina.com/
  * Plugin URI:  https://github.com/caffeinalab/sink
@@ -15,6 +15,6 @@ if (!defined('ABSPATH')) {
 
 define('SINK_URL', plugin_dir_url(__FILE__));
 define('SINK_PATH', plugin_dir_path(__FILE__));
-define('SINK_VERSION', '1.0.4');
+define('SINK_VERSION', '1.0.5');
 
 add_action('plugins_loaded', array('Sink\Sink', 'init'));


### PR DESCRIPTION
`is_plugin_active` doesn't exist on the frontend, but the plugin is not run on the frontend if it is not activated. It is run instead on the backend side so it should be checked there. 